### PR TITLE
chore(ci): migrate all workflows from PAT to GITHUB_TOKEN/App Token [SEC-58]

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -91,13 +91,20 @@ jobs:
           echo "New version: $NEW_VERSION_VALUE"
           echo ${{ steps.create-release.outputs.new_version }}
           echo "commit_summary=$SUMMARY" >> $GITHUB_OUTPUT
-          npx standard-version -a
+          npx standard-version -a --skip.commit --skip.tag
 
-      - name: Push new version in release branch & tag
+      - name: Create verified commit and tag via GitHub API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          git push --follow-tags
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: "chore(release): v${{ steps.create-release.outputs.new_version }}"
+          files: |
+            CHANGELOG.md
+            package.json
+            package-lock.json
+          tag: "v${{ steps.create-release.outputs.new_version }}"
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -8,10 +8,10 @@ permissions:
 
 jobs:
   draft-new-release:
-    permissions:
-      contents: write  # for Git to git push
     name: Draft a new release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to checkout repository
     if: startsWith(github.ref, 'refs/heads/feat') || startsWith(github.ref, 'refs/heads/fix/')
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -19,10 +19,20 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and push branches
+          permission-pull-requests: write # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set Node 16
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
@@ -41,6 +51,7 @@ jobs:
         id: create-release
         env:
           HUSKY: 0
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=release
@@ -83,6 +94,8 @@ jobs:
           npx standard-version -a
 
       - name: Push new version in release branch & tag
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git push --follow-tags
 
@@ -91,7 +104,7 @@ jobs:
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
           pr_reviewer: 'pallabmaiti'

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -38,27 +38,19 @@ jobs:
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 16
-          
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
 
       # Calculate the next release version based on conventional semantic release
-      - name: Create release branch
+      - name: Calculate release version
         id: create-release
         env:
           HUSKY: 0
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=release
           git fetch origin master --depth=1
           git merge origin/master
           current_version=$(jq -r .version package.json)
-          
+
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version=$(jq -r .version package.json)
           git reset --hard
@@ -70,14 +62,22 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
-          
+
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
           echo "NEW_VERSION_VALUE=$new_version" >> $GITHUB_ENV
+
+      - name: Create release branch via GitHub API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse origin/master)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f sha="$BASE_SHA"
 
       - name: Update changelog & bump version
         id: finish-release

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -46,6 +46,8 @@ on:
 jobs:
   request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # to read PR metadata for Notion sync
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -57,4 +59,4 @@ jobs:
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}
-          githubKey: ${{ secrets.PAT }}
+          githubKey: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -11,12 +11,22 @@ jobs:
   release:
     name: Publish new release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to checkout repository
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create tags and releases
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
@@ -30,6 +40,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set Node 16
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
@@ -45,8 +56,8 @@ jobs:
         id: create_release
         env:
           HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           npx conventional-github-releaser -p angular
 


### PR DESCRIPTION
## Summary
- Migrates all PAT usages to GITHUB_TOKEN or GitHub App Token based on workflow requirements
- Adds explicit permissions at job level with comments explaining why each permission is needed
- Follows January 2026 best practices for GitHub Actions security
- **Uses signed commits via GitHub API for verified release commits**
- **Simplified workflow using GitHub API for branch creation (no git push needed)**

### Files Changed
- `.github/workflows/notion-pr-sync.yml` - Migrated to GITHUB_TOKEN
- `.github/workflows/draft-new-release.yml` - Migrated to GitHub App Token + signed commits + simplified pattern
- `.github/workflows/publish-new-release.yml` - Migrated to GitHub App Token

### Migration Pattern Evolution

1. The signed-commit action (`ryancyq/github-signed-commit`) creates commits via GitHub's GraphQL API, producing **verified commits** with the App's identity
2. This eliminates the need for many git commands: `git config`, `git add`, `git commit`, `git push`
3. The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them

**What was removed from draft-new-release.yml:**
- ❌ `git config user.name/email` step (no longer needed - signed-commit uses App identity)
- ❌ `git checkout -b` + `git push --set-upstream` (replaced with GitHub API branch creation)

**What was added:**
- ✅ GitHub API branch creation: `gh api repos/${{ github.repository }}/git/refs --method POST`
- ✅ Creates branch from master SHA before signed-commit action runs

### Migration Details

| File | Token Type | Permissions | Reason |
|------|------------|-------------|--------|
| notion-pr-sync.yml | GITHUB_TOKEN | `pull-requests: read` | Only reads PR metadata for Notion sync |
| draft-new-release.yml | GitHub App Token | `contents: write`, `pull-requests: write` | Creates PRs that must trigger CI workflows |
| publish-new-release.yml | GitHub App Token | `contents: write` | Creates GitHub releases and tags |

### Key Changes

#### notion-pr-sync.yml
- Added job-level `permissions:` block with `pull-requests: read`
- Changed from `secrets.PAT` to `secrets.GITHUB_TOKEN`
- No App Token needed - workflow only reads PR data

#### draft-new-release.yml (Latest: Simplified Pattern)
- Added GitHub App Token generation step (before checkout)
- Changed job-level permissions to `contents: read` (minimal for GITHUB_TOKEN)
- Added App Token permissions: `permission-contents: write`, `permission-pull-requests: write`
- Updated checkout to use App Token
- **Removed `git config user.name/email` step** (not needed with signed commits)
- **Replaced `git checkout -b` + `git push` with GitHub API branch creation** (`gh api .../git/refs`)
- Uses `ryancyq/github-signed-commit` action for verified commits
- Updated `standard-version` to skip local commits/tags (`--skip.commit --skip.tag`)
- Updated PR creation to use App Token

#### publish-new-release.yml
- Added GitHub App Token generation step (before checkout)
- Added job-level permissions: `contents: read` (minimal for GITHUB_TOKEN)
- Added App Token permissions: `permission-contents: write`
- Updated checkout to use App Token
- Updated conventional-github-releaser to use App Token

### Security Improvements
- All permissions are now explicitly declared at job level (not workflow level)
- Each permission includes a comment explaining why it's needed
- Follows principle of least privilege
- App Tokens are generated early and used consistently throughout each job
- **Release commits are now verified using GitHub API instead of unverified git pushes**
- **No more tokens embedded in git remote URLs**

## Test plan
- [ ] Verify notion-pr-sync workflow still syncs PRs to Notion correctly
- [ ] Verify draft-new-release workflow can create release branches and PRs with verified commits
- [ ] Verify publish-new-release workflow can create GitHub releases
- [ ] Verify all linting checks pass (actionlint, zizmor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)